### PR TITLE
Fix bad License URL found by choco reviewer

### DIFF
--- a/Maven/Maven.nuspec
+++ b/Maven/Maven.nuspec
@@ -12,8 +12,8 @@
 	model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information</description>
     <projectUrl>http://maven.apache.org/</projectUrl>
     <tags>maven java development</tags>
-    <copyright>2002-2015 The Apache Software Foundation</copyright>
-    <licenseUrl>http://maven.apache.org/license.html</licenseUrl>
+    <copyright>2002-2016 The Apache Software Foundation</copyright>
+    <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>http://upload.wikimedia.org/wikipedia/commons/f/f5/Maven_logo.gif</iconUrl>
     <dependencies></dependencies>


### PR DESCRIPTION
Review of latest change has failed:
https://chocolatey.org/packages/maven/3.3.9

License URL has to be changed.

This PR fixes.
