### PR TITLE
Remove unnecessary environment variables

### DIFF
--- a/Maven/Maven.nuspec
+++ b/Maven/Maven.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>maven</id>
     <title>Maven</title>
-    <version>3.5.2.1</version>
+    <version>3.5.2.2</version>
     <authors>The Apache Maven team</authors>
     <owners>Michael Pereira, Jean-Pierre Matsumoto</owners>
     <summary>Apache Maven is a software project management and comprehension tool. Based on the concept of a project object 

--- a/Maven/tools/chocolateyInstall.ps1
+++ b/Maven/tools/chocolateyInstall.ps1
@@ -10,7 +10,6 @@ $name = "apache-maven-$version"
 $tools = Split-Path $MyInvocation.MyCommand.Definition
 $package = Split-Path $tools
 $m2_home = Join-Path $package $name
-$m2_bin = Join-Path $m2_home 'bin'
 $mvn_cmd = Join-Path $m2_home 'bin/mvn.cmd'
 $mvn_debug_cmd = Join-Path $m2_home 'bin/mvnDebug.cmd'
 $m2_repo = Join-Path $env:USERPROFILE '.m2'
@@ -19,9 +18,6 @@ $url = "https://archive.apache.org/dist/maven/maven-3/$version/binaries/$name-bi
 
 
 [Environment]::SetEnvironmentVariable('M2_HOME', $m2_home, "User")
-[Environment]::SetEnvironmentVariable('MAVEN_OPTS', '-Xms256m', "User")
-[Environment]::SetEnvironmentVariable('M2', $m2_bin, "User")
-[Environment]::SetEnvironmentVariable('M2_REPO', $m2_repo, "User")
 
 Install-ChocolateyZipPackage `
     -PackageName 'Maven' `

--- a/Maven/tools/chocolateyUninstall.ps1
+++ b/Maven/tools/chocolateyUninstall.ps1
@@ -3,15 +3,11 @@ $name = "apache-maven-$version"
 $tools = Split-Path $MyInvocation.MyCommand.Definition
 $package = Split-Path $tools
 $m2_home = Join-Path $package $name
-$m2_bin = Join-Path $m2_home 'bin'
 $mvn_cmd = Join-Path $m2_home 'bin/mvn.cmd'
 $mvn_debug_cmd = Join-Path $m2_home 'bin/mvnDebug.cmd'
-$m2_repo = Join-Path $env:USERPROFILE '.m2'
 
 [Environment]::SetEnvironmentVariable('M2_HOME', $null, "User")
-[Environment]::SetEnvironmentVariable('MAVEN_OPTS', $null, "User")
-[Environment]::SetEnvironmentVariable('M2', $null, "User")
-[Environment]::SetEnvironmentVariable('M2_REPO', $null, "User")
+
 
 Uninstall-BinFile -Name 'mvn' -Path $mvn_cmd
 Uninstall-BinFile -Name 'mvnDebug' -Path $mvn_debug_cmd


### PR DESCRIPTION
Contributing code to remove unnecessary environment variables as per http://disq.us/p/1onzgsd
I've decided to keep `M2_HOME` for now. While `M2_HOME` is no longer used by maven itself (see [Release Notes - Maven 3.5.0](https://maven.apache.org/docs/3.5.0/release-notes.html)), some external tools are still relying on `M2_HOME` to figure out where Maven is installed.
