### PR TITLE
Fix for unexpanding wrong strings in Path

### DIFF
--- a/Maven/Maven.nuspec
+++ b/Maven/Maven.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>maven</id>
     <title>Maven</title>
-    <version>3.6.1.20190624</version>
+    <version>3.6.1.20190711</version>
     <authors>The Apache Maven team</authors>
     <owners>Michael Pereira, Jean-Pierre Matsumoto, Anthony Accioly</owners>
     <summary>Apache Maven is a software project management and comprehension tool. Based on the concept of a project object 

--- a/Maven/tools/chocolateyUninstall.ps1
+++ b/Maven/tools/chocolateyUninstall.ps1
@@ -1,16 +1,23 @@
 [Environment]::SetEnvironmentVariable('M2_HOME', $null, 'Machine')
 
-#Using registry method prevents expansion (and loss) of environment variables (whether the target of the removal or not)
-#To avoid bad situations - does not use substring matching or regular expressions
-#Removes duplicates of the target removal path, Cleans up double ";", Handles ending "\"
+# Using registry method prevents expansion (and loss) of environment variables (whether the target of the removal or not)
+# To avoid bad situations - does not use substring matching or regular expressions
+# Removes duplicates of the target removal path, Cleans up double ";", Handles ending "\"
 $pathToRemove = Join-Path '%M2_HOME%' 'bin'
-$unexpandedPath = (Get-Item -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment').GetValue('Path', '', 'DoNotExpandEnvironmentNames') 
 
-foreach ($path in "$unexpandedPath".split(';')) {
-    if ($pathToRemove -ine $path -and "$pathToRemove\" -ine $path) {
-        [string[]]$newpath += "$path"
+try {
+    $regKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\CurrentControlSet\Control\Session Manager\Environment', $true)
+    $unexpandedPath = $regKey.GetValue('Path', $null, 'DoNotExpandEnvironmentNames')
+
+    foreach ($path in "$unexpandedPath".split(';')) {
+        if ($pathToRemove -ine $path -and "$pathToRemove\" -ine $path) {
+            [string[]]$newpath += "$path"
+        }
     }
-}
-$assembledNewPath = ($newpath -join (';')).trimend(';')
+    $assembledNewPath = ($newpath -join (';')).trimend(';')
 
-[Environment]::SetEnvironmentVariable('PATH', $assembledNewPath, 'Machine')
+    $regKey.SetValue("Path", $assembledNewPath, "ExpandString")
+}
+finally {
+    $regKey.Dispose()
+}


### PR DESCRIPTION
Fix to uninstaller "unexpanding" some built-in Path variables.

See http://disq.us/p/22ylfzz for further details.